### PR TITLE
Add mean and standard deviation calculator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,24 @@
+use std::io::{self};
+
 fn main() {
-    println!("Hello, world!");
+    let mut numbers = Vec::new();
+    println!("Enter ten numbers:");
+    for _ in 0..10 {
+        let mut line = String::new();
+        io::stdin().read_line(&mut line).expect("Failed to read input");
+        let value: f64 = line.trim().parse().expect("Invalid number");
+        numbers.push(value);
+    }
+
+    let mean: f64 = numbers.iter().sum::<f64>() / numbers.len() as f64;
+    let variance: f64 = numbers
+        .iter()
+        .map(|&x| (x - mean).powi(2))
+        .sum::<f64>()
+        / (numbers.len() as f64 - 1.0);
+    let std_dev = variance.sqrt();
+
+    println!("The mean is {:.2}", mean);
+    println!("The standard deviation is {:.5}", std_dev);
 }
+


### PR DESCRIPTION
## Summary
- implement CLI tool to read 10 numbers
- compute mean and standard deviation

## Testing
- `cargo build --quiet`
- `echo -e "10\n9\n8\n7\n6\n5.6\n5.5\n3\n2\n1" | cargo run --quiet`

------
https://chatgpt.com/codex/tasks/task_b_683f6e6741d4832a995197cb98d6bb85